### PR TITLE
Include sample spreadsheets in packaged builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Build the React frontend and package the Electron app into a Windows executable:
 npm run package
 ```
 
-The generated `release/NOCList-win32-x64` folder will contain `NOCList.exe`. Place
-`groups.xlsx` and `contacts.xlsx` next to the executable so the application can
-load them at runtime.
+The generated `release/NOCList-win32-x64` folder will contain `NOCList.exe`.
+Sample `contacts.xlsx` and `groups.xlsx` files are copied into the directory
+automatically so the packaged build can load them at runtime without any manual
+steps.
 
 If `public/icon.ico` exists it will be used as the Windows
 application icon.
@@ -93,7 +94,8 @@ npm run package:mac -- --skip-signing
 
 When shipping the app to end users you must sign it with a valid
 identity and submit the resulting `.app` bundle for Apple notarization
-to avoid Gatekeeper warnings.
+to avoid Gatekeeper warnings. Packaged macOS bundles will also include
+the sample Excel files inside `NOCList.app/Contents/MacOS/` automatically.
 
 ## Continuous Integration
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node start-app.js",
     "test": "vitest",
     "build": "vite build",
-    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true",
+    "package": "npm run build && electron-packager . NOCList --platform=win32 --arch=x64 --overwrite --out=release --icon=public/icon.ico --asar --prune=true && node scripts/copy-sample-data.mjs --target=windows",
     "package:mac": "node scripts/package-mac.mjs"
   },
   "dependencies": {

--- a/scripts/copy-sample-data.mjs
+++ b/scripts/copy-sample-data.mjs
@@ -1,0 +1,94 @@
+import { copyFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = dirname(__dirname);
+
+const SAMPLE_FILES = ['contacts.xlsx', 'groups.xlsx'];
+
+const TARGET_DIRECTORIES = {
+  windows: {
+    label: 'Windows release directory',
+    path: join(projectRoot, 'release', 'NOCList-win32-x64')
+  },
+  macos: {
+    label: 'macOS bundle directory',
+    path: join(
+      projectRoot,
+      'release',
+      'NOCList-darwin-arm64',
+      'NOCList.app',
+      'Contents',
+      'MacOS'
+    )
+  }
+};
+
+function normaliseTarget(target) {
+  return target?.toLowerCase();
+}
+
+function parseCliTargets() {
+  const values = [];
+
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith('--target=')) {
+      const targetArg = arg.slice('--target='.length);
+      values.push(...targetArg.split(',').map((value) => value.trim()).filter(Boolean));
+      continue;
+    }
+
+    if (!arg.startsWith('--')) {
+      values.push(arg);
+    }
+  }
+
+  return values.map(normaliseTarget).filter(Boolean);
+}
+
+export function copySampleData({ targets = ['windows', 'macos'] } = {}) {
+  const uniqueTargets = [...new Set(targets.map(normaliseTarget).filter(Boolean))];
+
+  if (uniqueTargets.length === 0) {
+    throw new Error('At least one target (windows or macos) must be specified.');
+  }
+
+  for (const target of uniqueTargets) {
+    const targetDetails = TARGET_DIRECTORIES[target];
+
+    if (!targetDetails) {
+      console.warn(`Unknown target "${target}". Valid options are: windows, macos.`);
+      continue;
+    }
+
+    if (!existsSync(targetDetails.path)) {
+      console.warn(
+        `Skipping sample data copy: ${targetDetails.label} not found at ${targetDetails.path}.`
+      );
+      continue;
+    }
+
+    for (const file of SAMPLE_FILES) {
+      const sourcePath = join(projectRoot, file);
+      const destinationPath = join(targetDetails.path, file);
+      copyFileSync(sourcePath, destinationPath);
+    }
+  }
+}
+
+function isExecutedDirectly() {
+  const invokedPath = process.argv[1];
+
+  if (!invokedPath) {
+    return false;
+  }
+
+  return pathToFileURL(invokedPath).href === import.meta.url;
+}
+
+if (isExecutedDirectly()) {
+  const cliTargets = parseCliTargets();
+  copySampleData(cliTargets.length > 0 ? { targets: cliTargets } : undefined);
+}

--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { copySampleData } from './copy-sample-data.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -168,6 +169,8 @@ function main() {
       '--asar',
       '--prune=true'
     ]);
+
+    copySampleData({ targets: ['macos'] });
 
     const { identity: signingIdentity, source: identitySource, skip } = parseSigningIdentity();
     const appPath = join(


### PR DESCRIPTION
## Summary
- copy the bundled Excel samples into Windows and macOS release folders via a shared helper
- invoke the new helper from both packaging workflows so archives ship with dummy data
- update documentation to note that packaged builds now include the spreadsheets automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db1773f3c48328a47c95ef2d0699dc