### PR TITLE
Fix contact list overflow causing window scrollbar

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -1234,6 +1234,7 @@ a[href^="mailto:"]:hover {
   max-width: 100%;
   border-radius: 18px;
   overflow-x: hidden;
+  box-sizing: border-box;
 }
 
 .contact-list__row {


### PR DESCRIPTION
## Summary
- ensure the contact search virtualized list container uses border-box sizing so its padding no longer expands the element height

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db38d388ac8328ad3e5610c885013d