### PR TITLE
Tighten contact search card layout and align tab width

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -383,12 +383,16 @@ body {
   gap: 1.5rem;
   --contact-header-height: 0px;
   --contact-list-offset: clamp(0.75rem, 1vw, 1.25rem);
+}
+
+.email-groups {
   --contact-grid-gap: clamp(1.25rem, 2vw, 1.9rem);
 }
 
 .contact-search {
   flex: 1 1 auto;
   min-height: 0;
+  --contact-grid-gap: clamp(0.85rem, 1.5vw, 1.35rem);
 }
 
 .button-group {
@@ -1257,19 +1261,29 @@ a[href^="mailto:"]:hover {
   flex: 1;
 }
 
+.contact-search__surface {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 1.6vw, 1.35rem);
+}
+
+.contact-search__surface.list-surface {
+  padding: clamp(0.85rem, 1.4vw, 1.15rem);
+}
+
 .contact-card {
   position: relative;
   background: var(--surface-raised);
-  border-radius: 22px;
-  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  border: 1px solid rgba(126, 158, 210, 0.28);
   color: var(--text-light);
   transition: transform 0.25s ease, box-shadow 0.25s ease, border 0.25s ease;
   animation: fade-in 0.3s ease;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 1.35rem;
+  gap: 0.65rem;
+  padding: clamp(0.95rem, 1.7vw, 1.2rem);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
   min-height: 100%;
@@ -1301,40 +1315,59 @@ a[href^="mailto:"]:hover {
 .contact-card__header {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .contact-card__avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 16px;
+  width: 42px;
+  height: 42px;
+  min-width: 42px;
+  border-radius: 14px;
   background: rgba(63, 131, 248, 0.18);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   color: var(--text-light);
   box-shadow: var(--glow-accent);
 }
 
+.contact-card__header > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
 .contact-card__name {
   margin: 0;
-  font-size: 1.15rem;
+  font-size: 1.05rem;
   font-weight: 700;
+  line-height: 1.3;
+  word-break: break-word;
 }
 
 .contact-card__title {
   margin: 0;
   color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.3;
 }
 
 .contact-card__row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem 0.5rem;
-  align-items: baseline;
-  font-size: 0.95rem;
+  gap: 0.2rem 0.45rem;
+  align-items: center;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.contact-card__row a,
+.contact-card__row span {
+  word-break: break-word;
 }
 
 .contact-card__row .label {
@@ -1342,13 +1375,16 @@ a[href^="mailto:"]:hover {
   color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
+  margin-right: 0.2rem;
 }
 
 .contact-card__actions {
   display: flex;
   justify-content: flex-start;
   margin-top: auto;
+  padding-top: 0.35rem;
+  gap: 0.5rem;
 }
 
 .list-surface {


### PR DESCRIPTION
## Summary
- center the contact search results inside the shared list surface so the tab body matches other modules and measure width from that constrained container
- observe the contact list surface for resize changes to keep virtualization dimensions in sync
- refresh contact card styling to tighten spacing, typography, and wrapping for a more compact layout

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68db3c8910f08328afe1b1a6909631d2