### PR TITLE
Compact contact cards and tighten radar frame

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -330,7 +330,7 @@ function App() {
         )}
 
         {tab === 'contact' && (
-          <div className="module-card">
+          <div className="module-card module-card--contacts">
             <ContactSearch
               contactData={contactData}
               addAdhocEmail={addAdhocEmail}

--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -14,11 +14,12 @@ import { toast } from 'react-hot-toast'
 import { formatPhones } from '../utils/formatPhones'
 import { findEmailAddress, getContactInitials } from '../utils/findEmailAddress'
 
-const MIN_COLUMN_WIDTH = 320
+const MIN_COLUMN_WIDTH = 260
 const MIN_LIST_HEIGHT = 320
 const LIST_BOTTOM_PADDING = 24
-const DEFAULT_ROW_HEIGHT = 340
-const DEFAULT_COLUMN_GAP = 24
+const DEFAULT_ROW_HEIGHT = 260
+const MIN_ROW_HEIGHT = 210
+const DEFAULT_COLUMN_GAP = 20
 
 const parsePxValue = (value) => {
   if (typeof value === 'number') {
@@ -434,7 +435,8 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
           Math.ceil(node.getBoundingClientRect().height || 0),
         )
 
-        const height = measuredHeight > 0 ? Math.max(measuredHeight, DEFAULT_ROW_HEIGHT) : DEFAULT_ROW_HEIGHT
+        const height =
+          measuredHeight > 0 ? Math.max(measuredHeight, MIN_ROW_HEIGHT) : DEFAULT_ROW_HEIGHT
         setRowHeight(index, height)
       }
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -352,8 +352,9 @@ body {
 }
 
 .app-shell--radar .module-card--radar {
-  width: 100%;
+  width: min(100%, clamp(540px, 78vw, 880px));
   max-width: none;
+  align-self: center;
 }
 
 .app-main--radar .radar-container,
@@ -364,7 +365,7 @@ body {
 
 .module-card {
   --module-pad: clamp(1.1rem, 2vw, 2.2rem);
-  width: min(100%, 1040px);
+  width: min(100%, 1140px);
   background: linear-gradient(150deg, rgba(21, 33, 56, 0.94), rgba(11, 17, 30, 0.92));
   backdrop-filter: blur(22px);
   border-radius: var(--radius-lg);
@@ -374,6 +375,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: clamp(1.05rem, 1.75vw, 1.85rem);
+}
+
+.module-card--radar {
+  --module-pad: clamp(0.85rem, 1.4vw, 1.2rem);
+  gap: clamp(0.75rem, 1.2vw, 1.05rem);
 }
 
 .email-groups,
@@ -392,7 +398,7 @@ body {
 .contact-search {
   flex: 1 1 auto;
   min-height: 0;
-  --contact-grid-gap: clamp(0.85rem, 1.5vw, 1.35rem);
+  --contact-grid-gap: clamp(0.7rem, 1.1vw, 1.05rem);
 }
 
 .button-group {
@@ -1205,25 +1211,28 @@ a[href^="mailto:"]:hover {
 
 
 .radar-frame-wrapper {
+  --radar-frame-padding: clamp(0.22rem, 0.6vw, 0.38rem);
   position: relative;
-  width: min(100%, 1100px);
+  width: 100%;
   flex: 1 1 auto;
-  border-radius: 24px;
-  border: 1px solid rgba(126, 158, 210, 0.32);
+  border-radius: 22px;
   background: linear-gradient(180deg, rgba(26, 39, 65, 0.92), rgba(15, 22, 37, 0.94));
   box-shadow: var(--shadow-lg);
   overflow: hidden;
   min-height: clamp(420px, 70vh, 900px);
   aspect-ratio: 16 / 10;
   display: flex;
+  padding: var(--radar-frame-padding);
 }
 
 .radar-frame {
   flex: 1 1 auto;
-  border: none;
+  width: 100%;
+  height: 100%;
+  border-radius: max(12px, calc(20px - var(--radar-frame-padding)));
+  border: 1px solid rgba(126, 158, 210, 0.32);
   display: block;
   background: transparent;
-  min-height: 100%;
 }
 
 .radar-fallback {
@@ -1283,7 +1292,7 @@ a[href^="mailto:"]:hover {
 }
 
 .contact-search__surface.list-surface {
-  padding: clamp(0.85rem, 1.4vw, 1.15rem);
+  padding: clamp(0.7rem, 1.15vw, 1rem);
 }
 
 .contact-card {
@@ -1297,8 +1306,8 @@ a[href^="mailto:"]:hover {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: clamp(1rem, 1.8vw, 1.4rem);
+  gap: clamp(0.3rem, 0.65vw, 0.55rem);
+  padding: clamp(0.65rem, 1.05vw, 0.85rem);
   box-shadow: var(--shadow-md);
   overflow: hidden;
   min-height: 100%;
@@ -1330,21 +1339,21 @@ a[href^="mailto:"]:hover {
 .contact-card__header {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: clamp(0.55rem, 0.9vw, 0.8rem);
   flex-wrap: wrap;
 }
 
 .contact-card__avatar {
-  width: 44px;
-  height: 44px;
-  min-width: 44px;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
   border-radius: 14px;
   background: rgba(63, 131, 248, 0.28);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 1.05rem;
+  font-size: 1rem;
   color: var(--text-light);
   box-shadow: var(--glow-accent);
 }
@@ -1352,7 +1361,7 @@ a[href^="mailto:"]:hover {
 .contact-card__header > div {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
   min-width: 0;
 }
 
@@ -1372,12 +1381,12 @@ a[href^="mailto:"]:hover {
 }
 
 .contact-card__row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem 0.65rem;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
   align-items: center;
-  font-size: 0.92rem;
-  line-height: 1.5;
+  gap: 0.2rem clamp(0.35rem, 0.75vw, 0.55rem);
+  font-size: 0.9rem;
+  line-height: 1.4;
 }
 
 .contact-card__row a,
@@ -1391,22 +1400,24 @@ a[href^="mailto:"]:hover {
   color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-size: 0.75rem;
-  margin-right: 0.2rem;
+  font-size: 0.72rem;
+  margin-right: 0;
 }
 
 .contact-card__actions {
   display: flex;
   justify-content: flex-start;
-  margin-top: auto;
-  padding-top: 0.75rem;
-  gap: 0.6rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: clamp(0.1rem, 0.35vw, 0.25rem);
+  padding-top: clamp(0.25rem, 0.5vw, 0.4rem);
+  gap: clamp(0.35rem, 0.65vw, 0.55rem);
   border-top: 1px solid rgba(126, 158, 210, 0.25);
 }
 
 .list-surface {
-  width: 100%;
-  max-width: clamp(840px, 90vw, 1200px);
+  width: min(100%, clamp(720px, 92vw, 1200px));
+  max-width: none;
   margin: 0 auto;
   background: var(--bg-elevated);
   border-radius: 20px;
@@ -1417,6 +1428,14 @@ a[href^="mailto:"]:hover {
   display: flex;
   flex-direction: column;
   gap: clamp(0.85rem, 1.25vw, 1.1rem);
+}
+
+.module-card--contacts {
+  width: min(100%, 1380px);
+}
+
+.module-card--contacts .list-surface {
+  width: min(100%, clamp(900px, 95vw, 1320px));
 }
 
 .list-surface > * {


### PR DESCRIPTION
## Summary
- lower the virtualized contact row minimum and shrink card padding so the buttons sit immediately below the phone details
- narrow the radar module width and reduce frame padding so the iframe border hugs the embedded dispatcher view

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dc30284c808328869ed3f6ce84fd04