### PR TITLE
Expand radar iframe to fill viewport

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -343,6 +343,10 @@ body {
 .app-main--radar {
   overflow-y: hidden;
   padding-bottom: clamp(1.2rem, 1.8vw, 2rem);
+  align-items: stretch;
+  justify-content: flex-start;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .app-main--radar .module-card--radar {
@@ -352,9 +356,9 @@ body {
 }
 
 .app-shell--radar .module-card--radar {
-  width: min(100%, clamp(540px, 78vw, 880px));
+  width: 100%;
   max-width: none;
-  align-self: center;
+  align-self: stretch;
 }
 
 .app-main--radar .radar-container,
@@ -380,6 +384,7 @@ body {
 .module-card--radar {
   --module-pad: clamp(0.85rem, 1.4vw, 1.2rem);
   gap: clamp(0.75rem, 1.2vw, 1.05rem);
+  width: 100%;
 }
 
 .email-groups,
@@ -1205,7 +1210,7 @@ a[href^="mailto:"]:hover {
   flex-direction: column;
   gap: 1rem;
   min-height: 0;
-  align-items: center;
+  align-items: stretch;
   justify-content: flex-start;
 }
 
@@ -1215,12 +1220,13 @@ a[href^="mailto:"]:hover {
   position: relative;
   width: 100%;
   flex: 1 1 auto;
+  height: 100%;
+  align-items: stretch;
   border-radius: 22px;
   background: linear-gradient(180deg, rgba(26, 39, 65, 0.92), rgba(15, 22, 37, 0.94));
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  min-height: clamp(420px, 70vh, 900px);
-  aspect-ratio: 16 / 10;
+  min-height: max(420px, 60vh);
   display: flex;
   padding: var(--radar-frame-padding);
 }
@@ -1228,7 +1234,8 @@ a[href^="mailto:"]:hover {
 .radar-frame {
   flex: 1 1 auto;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
+  height: auto;
   border-radius: max(12px, calc(20px - var(--radar-frame-padding)));
   border: 1px solid rgba(126, 158, 210, 0.32);
   display: block;
@@ -1278,11 +1285,10 @@ a[href^="mailto:"]:hover {
 .contact-card-wrapper {
   display: flex;
   min-width: 0;
-  height: 100%;
 }
 
 .contact-card-wrapper > .contact-card {
-  flex: 1;
+  flex: 1 1 auto;
 }
 
 .contact-search__surface {
@@ -1310,7 +1316,7 @@ a[href^="mailto:"]:hover {
   padding: clamp(0.65rem, 1.05vw, 0.85rem);
   box-shadow: var(--shadow-md);
   overflow: hidden;
-  min-height: 100%;
+  min-height: 0;
   scroll-margin-top: calc(var(--app-header-offset, 0px) + 1.5rem);
 }
 
@@ -1409,7 +1415,7 @@ a[href^="mailto:"]:hover {
   justify-content: flex-start;
   align-items: center;
   flex-wrap: wrap;
-  margin-top: clamp(0.1rem, 0.35vw, 0.25rem);
+  margin-top: auto;
   padding-top: clamp(0.25rem, 0.5vw, 0.4rem);
   gap: clamp(0.35rem, 0.65vw, 0.55rem);
   border-top: 1px solid rgba(126, 158, 210, 0.25);


### PR DESCRIPTION
## Summary
- let the dispatcher radar module stretch to the available viewport space so the iframe grows with the window and expands fully in both directions
- tighten the contact card layout so cards size to their content and the action buttons sit flush without excess padding

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dc3ac19c4083288e1a7f1d48959eae