### PR TITLE
Improve UI feedback and clipboard robustness

### DIFF
--- a/src/components/ContactSearch.jsx
+++ b/src/components/ContactSearch.jsx
@@ -15,6 +15,7 @@ import { formatPhones } from '../utils/formatPhones'
 import { findEmailAddress, getContactInitials } from '../utils/findEmailAddress'
 import { getPreferredPhoneValue } from '../utils/contactInfo'
 import { normalizeSearchText } from '../utils/normalizeText'
+import { notifyAdhocEmailResult } from '../utils/notifyAdhocEmailResult'
 
 const MIN_COLUMN_WIDTH = 260
 const MIN_LIST_HEIGHT = 320
@@ -535,8 +536,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
       </div>
 
       <div className="contact-search__surface list-surface minimal-scrollbar" ref={listSurfaceRef}>
-        {filtered.length > 0 ? (
-        listWidth > 0 && (
+        {filtered.length > 0 && listWidth > 0 ? (
           <VariableSizeList
             ref={listRef}
             height={listHeight}
@@ -576,14 +576,7 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
                       }
 
                       const result = addAdhocEmail(emailAddress, { switchToEmailTab: true })
-
-                      if (result === 'added') {
-                        toast.success(`Added ${emailAddress} to the list`)
-                      } else if (result === 'duplicate') {
-                        toast('Email already in list', { icon: 'ℹ️' })
-                      } else {
-                        toast.error('Invalid email address')
-                      }
+                      notifyAdhocEmailResult(emailAddress, result)
                     }
 
                     return (
@@ -636,7 +629,6 @@ const ContactSearch = ({ contactData, addAdhocEmail }) => {
               )
             }}
           </VariableSizeList>
-        )
         ) : (
           <div className="empty-state">No matching contacts.</div>
         )}

--- a/src/utils/notifyAdhocEmailResult.js
+++ b/src/utils/notifyAdhocEmailResult.js
@@ -1,0 +1,26 @@
+import { toast } from 'react-hot-toast'
+
+/**
+ * Display consistent toast feedback for ad-hoc email operations.
+ * @param {string} email - The email address targeted by the action.
+ * @param {'added' | 'duplicate' | 'invalid' | string} result - Result from addAdhocEmail.
+ * @param {object} [options]
+ * @param {string} [options.duplicateMessage]
+ */
+export const notifyAdhocEmailResult = (
+  email,
+  result,
+  { duplicateMessage = 'Email already in list' } = {},
+) => {
+  if (!result) {
+    return
+  }
+
+  if (result === 'added') {
+    toast.success(`Added ${email} to the list`)
+  } else if (result === 'duplicate') {
+    toast(duplicateMessage, { icon: 'ℹ️' })
+  } else if (result === 'invalid') {
+    toast.error('Invalid email address')
+  }
+}


### PR DESCRIPTION
## Summary
- validate stored tab preferences before applying them and guard persistence of invalid values
- centralize ad-hoc email toast handling and streamline the contact list rendering conditions
- harden email group clipboard copying, reuse toast helper for contact additions, and trim contact emails when checking duplicates

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68dc463020e48328972f2009f4aafd1b