### PR TITLE
Improve Excel watcher robustness and preload validation

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -21,6 +21,10 @@ contextBridge.exposeInMainWorld('nocListAPI', {
    * @param {(data: {emailData: any[], contactData: any[]}) => void} callback
    */
   onExcelDataUpdate: (callback) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+
     const handler = (_event, data) => callback(data)
     ipcRenderer.on('excel-data-updated', handler)
     return () => ipcRenderer.off('excel-data-updated', handler)
@@ -31,6 +35,10 @@ contextBridge.exposeInMainWorld('nocListAPI', {
    * @param {(message: string) => void} callback
    */
   onExcelWatchError: (callback) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+
     const handler = (_event, message) => callback(message)
     ipcRenderer.on('excel-watch-error', handler)
     return () => ipcRenderer.off('excel-watch-error', handler)
@@ -77,6 +85,10 @@ contextBridge.exposeInMainWorld('nocListAPI', {
    * @param {(result: {status: 'success' | 'error', message?: string}) => void} callback
    */
   onRadarCacheCleared: (callback) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+
     const channel = 'radar-cache-cleared'
     const handler = (_event, payload) => callback(payload)
     ipcRenderer.on(channel, handler)


### PR DESCRIPTION
## Summary
- ensure previous Excel watchers close cleanly and wait for writes to settle before reloading data
- add guard clauses around preload event subscriptions so non-function callbacks are safely ignored

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc50884b5883289be2fa6d12caf692