### PR TITLE
Improve renderer safety and contact directory UX

### DIFF
--- a/src/components/EmailGroups.jsx
+++ b/src/components/EmailGroups.jsx
@@ -88,12 +88,16 @@ const EmailGroups = ({
     [contactData],
   )
 
+  const contactSearchTerm = useMemo(
+    () => normalizeSearchText(deferredContactQuery),
+    [deferredContactQuery],
+  )
+
   const filteredContacts = useMemo(() => {
-    const term = normalizeSearchText(deferredContactQuery)
-    return term
-      ? indexedContacts.filter((contact) => contact.searchText.includes(term))
+    return contactSearchTerm
+      ? indexedContacts.filter((contact) => contact.searchText.includes(contactSearchTerm))
       : indexedContacts
-  }, [deferredContactQuery, indexedContacts])
+  }, [contactSearchTerm, indexedContacts])
 
   const groupMap = useMemo(
     () => new Map(groups.map((g) => [g.name, g.emails])),
@@ -523,17 +527,11 @@ const EmailGroups = ({
                 <div className="empty-state">No contacts match your search.</div>
               )}
             </div>
-            {indexedContacts.length > filteredContacts.length && (
-              <p className="small-muted m-0">
-                Showing the first {filteredContacts.length.toLocaleString()} contacts. Use search to
-                find others.
-              </p>
-            )}
-            {contactQuery && filteredContacts.length > 0 && indexedContacts.length === filteredContacts.length && (
+            {contactSearchTerm && filteredContacts.length > 0 ? (
               <p className="small-muted m-0">
                 Found {filteredContacts.length.toLocaleString()} matching contacts.
               </p>
-            )}
+            ) : null}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add a reusable helper to safely access active webContents, reducing duplicate guards and preventing radar cache clearing when no session is available
- streamline contact picker filtering logic and update messaging so the contact count reflects the active search term
- improve the contact directory viewport by handling layout initialization gracefully and clarifying empty-state messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc53ae928483289c86dfc6a6bc7579