### PR TITLE
Optimize Excel reload handling

### DIFF
--- a/loadExcelFiles.test.js
+++ b/loadExcelFiles.test.js
@@ -65,6 +65,27 @@ describe('incremental Excel loading', () => {
     expect(updated.contactData).toEqual([{ Name: 'Bob', Email: 'bob@example.com' }])
   })
 
+  it('reports which workbook changed', async () => {
+    const resultNoChange = await loadExcelFiles(groupsPath)
+    expect(resultNoChange).toEqual({
+      emailChanged: false,
+      contactChanged: false,
+      didUpdate: false,
+    })
+
+    const newContactWB = xlsx.utils.book_new()
+    const newContactSheet = xlsx.utils.json_to_sheet([{ Name: 'Cara', Email: 'cara@example.com' }])
+    xlsx.utils.book_append_sheet(newContactWB, newContactSheet, 'Sheet1')
+    xlsx.writeFile(newContactWB, contactsPath)
+
+    const resultContactChange = await loadExcelFiles(contactsPath)
+    expect(resultContactChange).toEqual({
+      emailChanged: false,
+      contactChanged: true,
+      didUpdate: true,
+    })
+  })
+
   it('retains cached data when groups file is missing', async () => {
     const initial = getCachedData()
     fs.unlinkSync(groupsPath)


### PR DESCRIPTION
## Summary
- track workbook signatures and normalize file paths to make Excel reloads resilient across platforms
- surface change metadata from `loadExcelFiles` and skip redundant renderer updates when data is unchanged
- reset cached signatures when data is cleared and extend unit coverage for the new behaviour

## Testing
- npm test -- --run
- npx vitest run loadExcelFiles.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc57fdeca88328849162d2eb0954bc